### PR TITLE
feat: add speedcurve integration template

### DIFF
--- a/workflow-templates/speedcurve.properties.json
+++ b/workflow-templates/speedcurve.properties.json
@@ -1,0 +1,4 @@
+{
+    "name": "Run SpeedCurve test",
+    "description": "Asks SpeedCurve to run a performance test for the given site. You'll need to have a secret SpeedCurve API key and the site_id related to your environment - if you don't have them, ask Piotr Grzywa"
+}

--- a/workflow-templates/speedcurve.yml
+++ b/workflow-templates/speedcurve.yml
@@ -1,0 +1,22 @@
+# https://www.notion.so/vuestorefront/How-to-add-SpeedCurve-GitHub-action-f0c9ed35f994473083be0dde44802e5b
+name: "Run SpeedCurve test"
+
+on:
+  deployment_status
+
+jobs:
+  speedcurve:
+    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.deployment.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    steps:
+      # the "deploy this Docker container" curl to VSF Cloud only starts the deployment, we don't know for sure when does it end
+      - name: 'Wait for container deployed on VSF Cloud to come online'
+        run: 'sleep 300'
+        shell: 'bash'
+
+      - name: 'Ask SpeedCurve to run performance tests'
+        uses: SpeedCurve-Metrics/speedcurve-test-action@v1.2.2
+        with:
+          api_key: ${{ secrets.SPEEDCURVE_API_KEY }}
+          site_id: # your site id here, it's 6 digits
+          note: commit ${{ github.event.deployment.sha }}

--- a/workflow-templates/speedcurve.yml
+++ b/workflow-templates/speedcurve.yml
@@ -6,17 +6,21 @@ on:
 
 jobs:
   speedcurve:
-    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.deployment.ref == 'refs/heads/develop'
+    if: github.event.deployment_status.state == 'success' && github.event.deployment.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
-      # the "deploy this Docker container" curl to VSF Cloud only starts the deployment, we don't know for sure when does it end
       - name: 'Wait for container deployed on VSF Cloud to come online'
         run: 'sleep 300'
         shell: 'bash'
+
+      - name: Shorten deployment commit SHA
+        id: vars
+        shell: bash
+        run: echo "::set-output name=sha_short::$(echo ${{ github.event.deployment.sha }} | cut -c1-8)"
 
       - name: 'Ask SpeedCurve to run performance tests'
         uses: SpeedCurve-Metrics/speedcurve-test-action@v1.2.2
         with:
           api_key: ${{ secrets.SPEEDCURVE_API_KEY }}
-          site_id: # your site id here, it's 6 digits
-          note: commit ${{ github.event.deployment.sha }}
+          site_id: 744017
+          note: commit ${{ steps.vars.outputs.sha_short }}


### PR DESCRIPTION
This is for https://docs.github.com/en/actions/using-workflows/using-starter-workflows

So that this speedcurve workflow I made appears in the "Actions" tab for each repository in our org. The workflow is useful for running performance tests on the service we use - SpeedCurve - for tracking the performance of our integrations. The workflow runs the tests after a deployment succeeds.

See https://www.notion.so/vuestorefront/How-to-add-SpeedCurve-GitHub-action-f0c9ed35f994473083be0dde44802e5b