### PR TITLE
chore: add shared renovate configuration

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -5,6 +5,7 @@
   "schedule": [
     "before 5am on Monday"
   ],
+  "branchPrefix": "deps/",
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -6,6 +6,12 @@
     "before 5am on Monday"
   ],
   "branchPrefix": "deps/",
+  "nvm": {
+    "enabled": false
+  },
+  "ignoreDeps": [
+    "node"
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -15,7 +15,12 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "groupName": "all non-major dependency bump",
       "groupSlug": "all-patch",
       "automerge": true

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -27,6 +27,10 @@
       ],
       "groupName": "all non-major dependency bump",
       "groupSlug": "all-patch",
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
       "automerge": true
     },
     {

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -55,6 +55,12 @@
     {
       "matchPackageNames": ["swc-plugin-coverage-instrument"],
       "enabled": false
+    },
+    {
+      "enabled": false,
+      "matchDepTypes": [
+        "engines"
+      ]
     }
   ]
 }

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "timezone": "Europe/Warsaw",
-  "extends": ["config:base", ":disableDependencyDashboard"],
+  "extends": ["config:base", ":disableDependencyDashboard", ":semanticCommitTypeAll(chore)"],
+  "npm": {
+    "commitMessageTopic": "{{prettyDepType}} {{depName}}",
+    "commitMessagePrefix": "chore(deps): :arrow_up: "
+  },
   "schedule": [
     "before 5am on Monday"
   ],

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "timezone": "Europe/Warsaw",
+  "extends": ["config:base", ":disableDependencyDashboard"],
+  "schedule": [
+    "before 5am on Monday"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "all non-major dependency bump",
+      "groupSlug": "all-patch",
+      "automerge": true
+    },
+    {
+      "extends": "packages:linters",
+      "groupName": "linters",
+      "automerge": true
+    },
+    {
+      "extends": "packages:postcss",
+      "groupName": "postcss packages"
+    },
+    {
+      "extends": "packages:test",
+      "groupName": "test packages",
+      "automerge": true
+    },
+    {
+      "groupName": "definitelyTyped",
+      "matchPackagePrefixes": ["@types/"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["swc-plugin-coverage-instrument"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
We need to host a renovate configuration that can be shared with whole organization in the **public** repository. Renovate [by default looks for a `renovate-config.json` file within `.github` repository](https://docs.renovatebot.com/config-presets/#organization-level-presets) - so let's use this repository for shared renovate config! <3 