### PR TITLE
chore: update renovate-config.json

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -19,12 +19,6 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "all major dependency bump",
-      "groupSlug": "all-major"
-    },
-    {
-      "matchPackagePatterns": ["*"],
       "matchUpdateTypes": [
         "minor",
         "patch",

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -19,6 +19,12 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "all major dependency bump",
+      "groupSlug": "all-major"
+    },
+    {
+      "matchPackagePatterns": ["*"],
       "matchUpdateTypes": [
         "minor",
         "patch",
@@ -51,10 +57,6 @@
       "groupName": "definitelyTyped",
       "matchPackagePrefixes": ["@types/"],
       "automerge": true
-    },
-    {
-      "matchPackageNames": ["swc-plugin-coverage-instrument"],
-      "enabled": false
     },
     {
       "enabled": false,


### PR DESCRIPTION
forgot about major bumps, without this section there would not be any PR raised for major versions :)
also, disabling swc-instrumenter should happen per repo level, not here 